### PR TITLE
In-memory journal for Receptors

### DIFF
--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/delivery/AtLeastOnceDeliverySupport.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/delivery/AtLeastOnceDeliverySupport.scala
@@ -5,6 +5,7 @@ import akka.persistence.AtLeastOnceDelivery.AtLeastOnceDeliverySnapshot
 import akka.persistence._
 import pl.newicom.dddd.delivery.protocol.alod.Delivered
 import pl.newicom.dddd.messaging.{EntityMessage, Message}
+import pl.newicom.dddd.persistence.SaveSnapshotRequest
 
 case class DeliveryStateSnapshot(state: DeliveryState, alodSnapshot: AtLeastOnceDeliverySnapshot)
 
@@ -53,7 +54,7 @@ trait AtLeastOnceDeliverySupport extends PersistentActor with AtLeastOnceDeliver
     case receipt: Delivered =>
       persist(receipt)(updateState)
 
-    case "snap" =>
+    case SaveSnapshotRequest =>
       val snapshot = new DeliveryStateSnapshot(deliveryState, getDeliverySnapshot)
       log.debug(s"Saving snapshot: $snapshot")
       saveSnapshot(snapshot)

--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/delivery/AtLeastOnceDeliverySupport.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/delivery/AtLeastOnceDeliverySupport.scala
@@ -64,6 +64,7 @@ trait AtLeastOnceDeliverySupport extends PersistentActor with AtLeastOnceDeliver
 
     case f @ SaveSnapshotFailure(metadata, reason) =>
       log.error(s"$f")
+      throw reason
 
   }
 

--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/persistence/ForgettingParticularEvents.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/persistence/ForgettingParticularEvents.scala
@@ -1,0 +1,9 @@
+package pl.newicom.dddd.persistence
+
+import akka.persistence.PersistentActor
+
+trait ForgettingParticularEvents {
+  this: PersistentActor =>
+
+  override def journalPluginId = "akka.persistence.journal.inmem"
+}

--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/persistence/RegularSnapshotting.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/persistence/RegularSnapshotting.scala
@@ -1,0 +1,29 @@
+package pl.newicom.dddd.persistence
+
+import akka.actor.Actor.Receive
+import akka.contrib.pattern.ReceivePipeline
+import akka.contrib.pattern.ReceivePipeline.Inner
+import akka.persistence.PersistentActor
+
+case class RegularSnapshottingConfig(interest: Receive, interval: Int)
+
+trait RegularSnapshotting {
+  this: PersistentActor with ReceivePipeline =>
+
+  def snapshottingConfig: RegularSnapshottingConfig
+
+  private var receivedSinceLastSnapshot: Int = 0
+
+  pipelineInner {
+    case msg ⇒
+      if (snapshottingConfig.interest.isDefinedAt(msg)) {
+        if (receivedSinceLastSnapshot >= snapshottingConfig.interval) {
+          receivedSinceLastSnapshot = 0
+          self ! SaveSnapshotRequest
+        } else {
+          receivedSinceLastSnapshot += 1
+        }
+      }
+      Inner(msg)
+  }
+}

--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/persistence/RegularSnapshotting.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/persistence/RegularSnapshotting.scala
@@ -2,8 +2,8 @@ package pl.newicom.dddd.persistence
 
 import akka.actor.Actor.Receive
 import akka.contrib.pattern.ReceivePipeline
-import akka.contrib.pattern.ReceivePipeline.Inner
-import akka.persistence.PersistentActor
+import akka.contrib.pattern.ReceivePipeline.{HandledCompletely, Inner}
+import akka.persistence.{SaveSnapshotSuccess, PersistentActor}
 
 case class RegularSnapshottingConfig(interest: Receive, interval: Int)
 
@@ -13,17 +13,34 @@ trait RegularSnapshotting {
   def snapshottingConfig: RegularSnapshottingConfig
 
   private var receivedSinceLastSnapshot: Int = 0
+  private var saveSnapshotRequestInProcess: Boolean = false
 
-  pipelineInner {
-    case msg ⇒
-      if (snapshottingConfig.interest.isDefinedAt(msg)) {
-        if (receivedSinceLastSnapshot >= snapshottingConfig.interval) {
-          receivedSinceLastSnapshot = 0
-          self ! SaveSnapshotRequest
-        } else {
-          receivedSinceLastSnapshot += 1
-        }
-      }
+  private def snapshottingInterval: Int =
+    snapshottingConfig.interval
+
+  private def isTimeForSnapshot(extraInterval: Int = 0): Boolean =
+    (receivedSinceLastSnapshot - extraInterval) >= snapshottingInterval
+
+  pipelineOuter {
+    case ssr @ SaveSnapshotRequest if saveSnapshotRequestInProcess =>
+        if (isTimeForSnapshot(extraInterval = snapshottingInterval))
+          Inner(ssr) // should not happen
+        else
+          HandledCompletely
+
+    case sss @ SaveSnapshotSuccess(_) =>
+      saveSnapshotRequestInProcess = false
+      receivedSinceLastSnapshot = 0
+      Inner(sss)
+
+    case msg if isMessageCounted(msg) =>
+      if (isTimeForSnapshot())
+        self ! SaveSnapshotRequest
+      receivedSinceLastSnapshot += 1
       Inner(msg)
+  }
+
+  def isMessageCounted(msg: Any): Boolean = {
+    snapshottingConfig.interest.isDefinedAt(msg)
   }
 }

--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/persistence/SaveSnapshotRequest.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/persistence/SaveSnapshotRequest.scala
@@ -1,0 +1,3 @@
+package pl.newicom.dddd.persistence
+
+case object SaveSnapshotRequest

--- a/akka-ddd-test/src/test/scala/pl/newicom/dddd/process/SagaManagerIntegrationSpec.scala
+++ b/akka-ddd-test/src/test/scala/pl/newicom/dddd/process/SagaManagerIntegrationSpec.scala
@@ -9,6 +9,7 @@ import pl.newicom.dddd.eventhandling.LocalPublisher
 import pl.newicom.dddd.office.LocalOffice._
 import pl.newicom.dddd.process.SagaManagerIntegrationSpec._
 import pl.newicom.dddd.process.SagaSupport.{SagaManagerFactory, registerSaga}
+import pl.newicom.dddd.persistence.SaveSnapshotRequest
 import pl.newicom.dddd.test.dummy
 import pl.newicom.dddd.test.dummy.DummyAggregateRoot.{ChangeValue, CreateDummy, ValueChanged}
 import pl.newicom.dddd.test.dummy.DummySaga.{DummySagaConfig, EventApplied}
@@ -142,7 +143,7 @@ class SagaManagerIntegrationSpec extends OfficeSpec[DummyAggregateRoot](Some(int
   }
 
   def expectNumberOfUnconfirmedMessages(sagaManager: ActorRef, expectedNumberOfMessages: Int): Unit = within(3.seconds) {
-    sagaManager ! "snap"
+    sagaManager ! SaveSnapshotRequest
     awaitAssert {
       sagaManager ! GetNumberOfUnconfirmed
       expectMsg(expectedNumberOfMessages)

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val `akka-ddd-core` = project
     scalacOptions ++= Seq("-language:implicitConversions"),
     publishArtifact in Test := true,
     libraryDependencies ++= Seq(
-      Akka.clusterTools, Akka.clusterSharding, Akka.persistence, Akka.slf4j
+      Akka.clusterTools, Akka.clusterSharding, Akka.persistence, Akka.contributions, Akka.slf4j
     ))
   .dependsOn(`akka-ddd-messaging`)
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -31,6 +31,7 @@ object Deps {
     val persistence       = apply("persistence")
     val clusterTools      = apply("cluster-tools")
     val clusterSharding   = apply("cluster-sharding")
+    val contributions     = apply("contrib")
     val testkit           = apply("testkit")
     val multiNodeTestkit  = apply("multi-node-testkit")
 


### PR DESCRIPTION
Receptors should save their state (snapshot) regularly (every X events) to persistent snapshot store and should not care about particular events (stored in-memory) being "lost" in case of a failure. "Lost" events will be refetched automatically from the EventStream after Receptor's recovery. 
