### PR TITLE
Saga should process events in order they were stored in ES

### DIFF
--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/messaging/Deduplication.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/messaging/Deduplication.scala
@@ -2,31 +2,46 @@ package pl.newicom.dddd.messaging
 
 import akka.contrib.pattern.ReceivePipeline
 import akka.contrib.pattern.ReceivePipeline.{Inner, HandledCompletely}
-
 import scala.collection.mutable
 
+/**
+  * Designed to be used by persistent actors. Allows detecting duplicated messages sent to the actor.
+  * Keeps a set of message IDs that were received by the actor.
+  * Additionally keeps an ID of recently received message that is used by Saga to detect out-of-order messages.
+  *
+  * Provides messageProcessed(Message) method that should be called during the "update-state" stage.
+  * The given message must contain [[pl.newicom.dddd.messaging.MetaData.CausationId]] attribute
+  * referring to the ID of the received message.
+  */
 trait Deduplication {
   this: ReceivePipeline =>
-
-  private val processedMessages: mutable.Set[String] = mutable.Set.empty
+  private val ids: mutable.Set[String] = mutable.Set.empty
+  private var _idOfRecentlyReceivedMsg: Option[String] = None
 
   pipelineInner {
-    case m: Message =>
-      if (wasProcessed(m)) {
-        handleDuplicated(m)
+    case msg: Message =>
+      if (wasReceived(msg)) {
+        handleDuplicated(msg)
         HandledCompletely
       } else {
-        Inner(m)
+        Inner(msg)
       }
   }
 
-  def handleDuplicated(m: Message)
+  def handleDuplicated(msg: Message)
 
-  def messageProcessed(m: Message): Unit = {
-    processedMessages += m.id
+  def messageProcessed(msg: Message): Unit =
+    msg.causationId.foreach(messageReceived)
+
+  def idOfRecentlyReceivedMessage: Option[String] =
+    _idOfRecentlyReceivedMsg
+
+  private def wasReceived(msg: Message): Boolean =
+    ids.contains(msg.id)
+
+  private def messageReceived(msgId: String): Unit = {
+    ids += msgId
+    _idOfRecentlyReceivedMsg = Some(msgId)
   }
-
-  def wasProcessed(m: Message): Boolean =
-    processedMessages.contains(m.id)
 
 }

--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/process/Receptor.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/process/Receptor.scala
@@ -79,7 +79,10 @@ abstract class Receptor extends AtLeastOnceDeliverySupport with ReceptorPersiste
   def deadLetters = context.system.deadLetters.path
 
   def destination(msg: Message): ActorPath =
-    config.receiverResolver.applyOrElse(msg, (any: Message) => deadLetters)
+    config.receiverResolver.applyOrElse(msg, (any: Message) => {
+      log.warning("No destination provided")
+      deadLetters
+    })
 
   override lazy val persistenceId: String =
     s"Receptor-${config.stimuliSource.id}-${self.path.hashCode}"
@@ -93,7 +96,7 @@ abstract class Receptor extends AtLeastOnceDeliverySupport with ReceptorPersiste
         demandConfig          = DemandConfig(
                                   subscriberCapacity = config.capacity,
                                   initialDemand = config.capacity - unconfirmedNumber)))
-    log.info(s"$persistenceId subscribed to '${config.stimuliSource.id}' event stream from position: ${lastSentDeliveryId.getOrElse(0)}.")
+    log.info(s"Receptor $persistenceId subscribed to '${config.stimuliSource.id}' event stream from position: ${lastSentDeliveryId.getOrElse(0)}.")
   }
 
 

--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/process/Saga.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/process/Saga.scala
@@ -5,11 +5,12 @@ import pl.newicom.dddd.aggregate._
 import pl.newicom.dddd.delivery.protocol.alod._
 import pl.newicom.dddd.messaging.event.{OfficeEventMessage, EventMessage}
 
+case object EventDroppedMarkerEvent extends DomainEvent
+
 sealed trait SagaAction
 
 case class  RaiseEvent(e: DomainEvent)  extends SagaAction
 case object DropEvent                   extends SagaAction
-case object RejectEvent                 extends SagaAction
 
 trait SagaAbstractStateHandling {
   type ReceiveEvent = PartialFunction[DomainEvent, SagaAction]
@@ -32,23 +33,33 @@ abstract class Saga extends SagaBase {
 
   override def receiveCommand: Receive = {
     case em @ OfficeEventMessage(caseId, event, id, timestamp, metadata) =>
-      val action = receiveEvent(event)
-      action match {
-        case RaiseEvent(raisedEvent) =>
-          // TODO caseId of original OEM will be lost, consider storing it in metadata
-          val raisedEventMsg = if (raisedEvent == event) em else EventMessage(raisedEvent)
-          persist(raisedEventMsg) { persisted =>
-            log.debug("Event message persisted: {}", persisted)
-            _updateState(persisted)
-            acknowledgeEvent(persisted)
-          }
-        case DropEvent =>
-          acknowledgeEvent(em)
-        case RejectEvent =>
-          // rejected event should be redelivered by SagaManager
-      }
-      onEventReceived(em, action)
+      val actionMaybe: Option[SagaAction] =
+        em.previouslySentMsgId.fold(Option(receiveEvent(event))) { msgId =>
+          idOfRecentlyReceivedMessage.filter(_ == msgId)
+            .map(_ => receiveEvent(event))
+        }
 
+      if (actionMaybe.isEmpty) {
+        log.debug("Message out of order detected: {}", em.id)
+      } else {
+        val action  = actionMaybe.get
+        val eventToPersist = action match {
+          case RaiseEvent(raisedEvent) => raisedEvent
+          case DropEvent => EventDroppedMarkerEvent
+        }
+
+        val emToPersist = EventMessage(eventToPersist)
+          .withMetaData(metadata)
+          .withCausationId(id)
+
+        persist(emToPersist) { persisted =>
+          log.debug("Event message persisted: {}", persisted)
+          _updateState(persisted)
+          acknowledgeEvent(persisted)
+        }
+
+        onEventReceived(em, action)
+      }
     case receipt: Delivered =>
       persist(EventMessage(receipt))(_updateState)
   }
@@ -59,16 +70,18 @@ abstract class Saga extends SagaBase {
         confirmDelivery(receipt.deliveryId)
         updateState(receipt)
 
-      case em: EventMessage =>
-        messageProcessed(em)
-        updateState(em.event)
+      case em: EventMessage => em.event match {
+        case EventDroppedMarkerEvent =>
+          messageProcessed(em)
+        case event =>
+          messageProcessed(em)
+          updateState(event)
+      }
     }
   }
 
   def onEventReceived(em: EventMessage, appliedAction: SagaAction): Unit = {
     appliedAction match {
-      case RejectEvent =>
-        log.warning(s"Event message rejected: $em")
       case DropEvent =>
         log.debug(s"Event dropped: ${em.event}")
       case RaiseEvent(e) =>

--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/process/SagaBase.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/process/SagaBase.scala
@@ -57,16 +57,16 @@ trait SagaBase extends BusinessEntity with GracefulPassivation with PersistentAc
     log.debug(s"Delivery receipt (for received event) sent ($deliveryReceipt)")
   }
 
-  override def messageProcessed(m: Message): Unit = {
-    _lastEventMessage = m match {
+  override def messageProcessed(msg: Message): Unit = {
+    _lastEventMessage = msg match {
       case em: EventMessage =>
         Some(em)
       case _ => None
     }
-    super.messageProcessed(m)
+    super.messageProcessed(msg)
   }
 
-  override def handleDuplicated(m: Message) =
-    acknowledgeEvent(m)
+  override def handleDuplicated(msg: Message) =
+    acknowledgeEvent(msg)
 
 }

--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/process/SagaManager.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/process/SagaManager.scala
@@ -24,7 +24,9 @@ class SagaManager[E <: Saga](implicit val sagaOffice: SagaOffice[E]) extends Rec
 
   override def metaDataProvider(em: OfficeEventMessage): Option[MetaData] =
     sagaOffice.config.correlationIdResolver.lift(em.event).map { correlationId =>
-      MetaData(Map(CorrelationId -> correlationId))
+      MetaData(Map(
+        CorrelationId -> correlationId
+      ))
     }
 
 }

--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/process/SagaManager.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/process/SagaManager.scala
@@ -13,11 +13,10 @@ class SagaManager[E <: Saga](implicit val sagaOffice: SagaOffice[E]) extends Rec
   def defaultConfig: ReceptorConfig =
     ReceptorBuilder()
       .reactTo(sagaOffice.businessProcess)
-      .propagateTo(sagaOffice.actor.path)
+      .propagateTo(sagaOffice.actorPath)
 
 
   lazy val config = defaultConfig
-
 
   override def redeliverInterval = 30.seconds
   override def warnAfterNumberOfUnconfirmedAttempts = 15
@@ -29,4 +28,8 @@ class SagaManager[E <: Saga](implicit val sagaOffice: SagaOffice[E]) extends Rec
       ))
     }
 
+  override def recoveryCompleted(): Unit = {
+    super.recoveryCompleted()
+    log.info(s"SagaManager: $persistenceId for Saga office: ${sagaOffice.actorPath} is up and running.")
+  }
 }

--- a/akka-ddd-core/src/main/scala/pl/newicom/dddd/process/SagaStateHandling.scala
+++ b/akka-ddd-core/src/main/scala/pl/newicom/dddd/process/SagaStateHandling.scala
@@ -32,7 +32,7 @@ trait SagaStateHandling[S <: SagaState[S]] extends SagaAbstractStateHandling {
     case e: DomainEvent if canHandle(e) =>
       RaiseEvent(e)
     case _ =>
-      RejectEvent
+      DropEvent
   }
 
   def updateState(event: DomainEvent): Unit = {

--- a/akka-ddd-messaging/src/main/scala/pl/newicom/dddd/messaging/Message.scala
+++ b/akka-ddd-messaging/src/main/scala/pl/newicom/dddd/messaging/Message.scala
@@ -10,7 +10,8 @@ object MetaData {
   val DeliveryId          = "_deliveryId"
   val CausationId         = "causationId"
   val CorrelationId       = "correlationId"
-  val PreviouslySentMsgId = "previouslySentMsgId"
+  // contains ID of a message that the recipient of this message should process before it can process this message
+  val MustFollow          = "_mustFollow"
   val SessionId           = "sessionId"
 
   def empty: MetaData = MetaData(Map.empty)
@@ -84,7 +85,7 @@ trait Message extends Serializable {
 
   def withCausationId(causationId: EntityId) = withMetaAttribute(CausationId, causationId)
 
-  def withPreviouslySentMsgId(msgIdOpt: Option[String]) = msgIdOpt.map(msgId => withMetaAttribute(PreviouslySentMsgId, msgId)).getOrElse(this.asInstanceOf[MessageImpl])
+  def withMustFollow(mustFollow: Option[String]) = mustFollow.map(msgId => withMetaAttribute(MustFollow, msgId)).getOrElse(this.asInstanceOf[MessageImpl])
 
   def withSessionId(sessionId: EntityId) = withMetaAttribute(SessionId, sessionId)
 
@@ -97,5 +98,5 @@ trait Message extends Serializable {
 
   def causationId: Option[EntityId] = tryGetMetaAttribute[EntityId](CausationId)
 
-  def previouslySentMsgId: Option[String] = tryGetMetaAttribute[String](PreviouslySentMsgId)
+  def mustFollow: Option[String] = tryGetMetaAttribute[String](MustFollow)
 }

--- a/akka-ddd-messaging/src/main/scala/pl/newicom/dddd/messaging/Message.scala
+++ b/akka-ddd-messaging/src/main/scala/pl/newicom/dddd/messaging/Message.scala
@@ -10,6 +10,7 @@ object MetaData {
   val DeliveryId          = "_deliveryId"
   val CausationId         = "causationId"
   val CorrelationId       = "correlationId"
+  val PreviouslySentMsgId = "previouslySentMsgId"
   val SessionId           = "sessionId"
 
   def empty: MetaData = MetaData(Map.empty)
@@ -83,6 +84,8 @@ trait Message extends Serializable {
 
   def withCausationId(causationId: EntityId) = withMetaAttribute(CausationId, causationId)
 
+  def withPreviouslySentMsgId(msgIdOpt: Option[String]) = msgIdOpt.map(msgId => withMetaAttribute(PreviouslySentMsgId, msgId)).getOrElse(this.asInstanceOf[MessageImpl])
+
   def withSessionId(sessionId: EntityId) = withMetaAttribute(SessionId, sessionId)
 
   def deliveryId: Option[Long] = tryGetMetaAttribute[Any](DeliveryId).map {
@@ -92,4 +95,7 @@ trait Message extends Serializable {
 
   def correlationId: Option[EntityId] = tryGetMetaAttribute[EntityId](CorrelationId)
 
+  def causationId: Option[EntityId] = tryGetMetaAttribute[EntityId](CausationId)
+
+  def previouslySentMsgId: Option[String] = tryGetMetaAttribute[String](PreviouslySentMsgId)
 }

--- a/akka-ddd-monitoring/src/main/scala/pl/newicom/dddd/monitoring/SagaMonitoring.scala
+++ b/akka-ddd-monitoring/src/main/scala/pl/newicom/dddd/monitoring/SagaMonitoring.scala
@@ -9,11 +9,13 @@ trait SagaMonitoring extends SagaAbstractStateHandling with TraceContextSupport 
 
   override abstract def updateState(event: DomainEvent): Unit = {
     super.updateState(event)
-    if (!recoveryRunning) {
+    val reactionOnEvent: Option[Long] = currentEventMsg.tryGetMetaAttribute(Reaction_On_Event.shortName)
+
+    if (!recoveryRunning && reactionOnEvent.isDefined) {
       // finish 'reaction' record
       newLocalTraceContext(
         name            = Reaction_On_Event.traceContextName(officeId, currentEventMsg),
-        startedOnNanos = currentEventMsg.getMetaAttribute(Reaction_On_Event.shortName)
+        startedOnNanos = reactionOnEvent.get
       ).foreach(
         _.finish()
       )

--- a/akka-ddd-scheduling/src/main/scala/pl/newicom/dddd/scheduling/DeadlinesReceptor.scala
+++ b/akka-ddd-scheduling/src/main/scala/pl/newicom/dddd/scheduling/DeadlinesReceptor.scala
@@ -2,8 +2,8 @@ package pl.newicom.dddd.scheduling
 
 import akka.actor.ActorPath
 import pl.newicom.dddd.aggregate.EntityId
-import pl.newicom.dddd.messaging.event.EventMessage
-import pl.newicom.dddd.process.{ReceptorBuilder, ReceptorConfig}
+import pl.newicom.dddd.messaging.event.{EventStreamSubscriber, EventMessage}
+import pl.newicom.dddd.process.{Receptor, ReceptorBuilder, ReceptorConfig}
 
 object DeadlinesReceptor {
   def apply(businessUnit: EntityId): ReceptorConfig = ReceptorBuilder()
@@ -18,4 +18,11 @@ object DeadlinesReceptor {
       case em: EventMessage =>
         ActorPath.fromString(em.getMetaAttribute("target"))
     }
+}
+
+abstract class DeadlinesReceptor extends Receptor {
+  this: EventStreamSubscriber =>
+
+  override def isSupporting_MustFollow_Attribute: Boolean = false
+
 }

--- a/akka-ddd-test/src/test/scala/pl/newicom/dddd/process/SagaManagerIntegrationSpec.scala
+++ b/akka-ddd-test/src/test/scala/pl/newicom/dddd/process/SagaManagerIntegrationSpec.scala
@@ -128,8 +128,8 @@ class SagaManagerIntegrationSpec extends OfficeSpec[DummyAggregateRoot](Some(int
       sagaManager = registerSaga[DummySaga](sagaOffice)
 
       // then
-      expectNumberOfEventsAppliedBySaga(2)
-      expectNoUnconfirmedMessages(sagaManager)
+      expectNumberOfEventsAppliedBySaga(1)
+      expectNumberOfUnconfirmedMessages(sagaManager, 0)
 
     }
   }

--- a/akka-ddd-test/src/test/scala/pl/newicom/dddd/process/SagaSpec.scala
+++ b/akka-ddd-test/src/test/scala/pl/newicom/dddd/process/SagaSpec.scala
@@ -81,7 +81,7 @@ class SagaSpec extends TestKit(TestConfig.testSystem) with WordSpecLike with Imp
 
       val em1 = toEventMessage(ValueChanged(processId, 1, 1L))
       val em2 = toEventMessage(ValueChanged(processId, 2, 2L), previouslySentMsg = Some(em1))
-        .withPreviouslySentMsgId(Some("0"))
+        .withMustFollow(Some("0"))
 
       // When
       sagaOffice ! em1
@@ -114,7 +114,7 @@ class SagaSpec extends TestKit(TestConfig.testSystem) with WordSpecLike with Imp
     OfficeEventMessage(CaseId(entityId, event.dummyVersion), event).withMetaData(Map(
       CorrelationId -> entityId,
       DeliveryId -> 1L
-    )).withPreviouslySentMsgId(previouslySentMsg.map(msg => msg.id))
+    )).withMustFollow(previouslySentMsg.map(msg => msg.id))
   }
 
   def ensureActorTerminated(actor: ActorRef) = {

--- a/akka-ddd-test/src/test/scala/pl/newicom/dddd/process/SagaSpec.scala
+++ b/akka-ddd-test/src/test/scala/pl/newicom/dddd/process/SagaSpec.scala
@@ -27,22 +27,12 @@ class SagaSpec extends TestKit(TestConfig.testSystem) with WordSpecLike with Imp
   }
 
   implicit object TestSagaActorFactory extends SagaActorFactory[DummySaga] {
-    override def props(pc: PassivationConfig): Props = {
-      Props(new DummySaga(pc, officeId, None) {
-        override def onEventReceived(em: EventMessage, action: SagaAction) = {
-          action match {
-            case RejectEvent =>
-              system.eventStream.publish(em.event)
-            case _ =>
-          }
-          super.onEventReceived(em, action)
-        }
-      })
-    }
+    override def props(pc: PassivationConfig): Props =
+      Props(new DummySaga(pc, officeId, None))
   }
 
   def processId = uuid10
-  val sagaOffice = office[DummySaga].actor
+  lazy val sagaOffice = office[DummySaga].actor
 
   "Saga" should {
     "not process previously processed events" in {
@@ -63,6 +53,49 @@ class SagaSpec extends TestKit(TestConfig.testSystem) with WordSpecLike with Imp
   }
 
   "Saga" should {
+    "process messages received in order" in {
+      // Given
+      val probe = TestProbe()
+      system.eventStream.subscribe(probe.ref, classOf[EventApplied])
+
+      val em1 = toEventMessage(ValueChanged(processId, 1, 1L))
+
+      // When
+      sagaOffice ! em1
+      // Then
+      probe.expectMsgClass(classOf[EventApplied])
+
+      // When
+      sagaOffice ! toEventMessage(ValueChanged(processId, 2, 2L), previouslySentMsg = Some(em1))
+      // Then
+      probe.expectMsgClass(classOf[EventApplied])
+      probe.expectNoMsg(1.seconds)
+    }
+  }
+
+  "Saga" should {
+    "not process message received out of order" in {
+      // Given
+      val probe = TestProbe()
+      system.eventStream.subscribe(probe.ref, classOf[EventApplied])
+
+      val em1 = toEventMessage(ValueChanged(processId, 1, 1L))
+      val em2 = toEventMessage(ValueChanged(processId, 2, 2L), previouslySentMsg = Some(em1))
+        .withPreviouslySentMsgId(Some("0"))
+
+      // When
+      sagaOffice ! em1
+      // Then
+      probe.expectMsgClass(classOf[EventApplied])
+
+      // When
+      sagaOffice ! em2
+      // Then
+      probe.expectNoMsg(1.seconds)
+    }
+  }
+
+  "Saga" should {
     "acknowledge previously processed events" in {
       // Given
       val em1 = toEventMessage(ValueChanged(processId, 1, 1L))
@@ -76,11 +109,12 @@ class SagaSpec extends TestKit(TestConfig.testSystem) with WordSpecLike with Imp
     }
   }
 
-  def toEventMessage(event: ValueChanged): EventMessage = {
-    OfficeEventMessage(CaseId(processId, event.dummyVersion), event).withMetaData(Map(
-      CorrelationId -> processId,
+  def toEventMessage(event: ValueChanged, previouslySentMsg: Option[EventMessage] = None): EventMessage = {
+    val entityId = previouslySentMsg.flatMap(msg => msg.correlationId).getOrElse(processId)
+    OfficeEventMessage(CaseId(entityId, event.dummyVersion), event).withMetaData(Map(
+      CorrelationId -> entityId,
       DeliveryId -> 1L
-    ))
+    )).withPreviouslySentMsgId(previouslySentMsg.map(msg => msg.id))
   }
 
   def ensureActorTerminated(actor: ActorRef) = {


### PR DESCRIPTION
Currently, due to At-Least-Once-Delivery semantics, it possible that Saga will receive and process event E2 before event E1 although E1 was stored before E2 in the Event Store.
