### PR TITLE
MetaData Tags merging

### DIFF
--- a/akka-ddd-messaging/src/main/scala/pl/newicom/dddd/saga/ProcessConfig.scala
+++ b/akka-ddd-messaging/src/main/scala/pl/newicom/dddd/saga/ProcessConfig.scala
@@ -20,7 +20,7 @@ object ProcessConfig {
 }
 
 abstract class ProcessConfig[E : ClassTag](val process: BusinessProcessId)
-  extends LocalOfficeId[E](process.processDomain, Option(process.department).getOrElse(process.processDomain)) {
+  extends LocalOfficeId[E](process.processId, Option(process.department).getOrElse(process.processDomain)) {
 
   /**
     * Correlation ID identifies process instance.

--- a/akka-ddd-protocol/src/main/scala/pl/newicom/dddd/messaging/MetaAttribute.scala
+++ b/akka-ddd-protocol/src/main/scala/pl/newicom/dddd/messaging/MetaAttribute.scala
@@ -41,7 +41,7 @@ object MetaAttribute extends Enum[MetaAttribute[_]] {
 
   case object Tags extends MetaAttribute[Set[String]] {
     def merge(md1: MetaData, md2: MetaData): Set[String] = {
-      (md1.tryGet(Tags) ++ md1.tryGet(Tags)).flatten.toSet
+      (md1.tryGet(Tags) ++ md2.tryGet(Tags)).flatten.toSet
     }
   }
 

--- a/akka-ddd-protocol/src/main/scala/pl/newicom/dddd/messaging/MetaAttribute.scala
+++ b/akka-ddd-protocol/src/main/scala/pl/newicom/dddd/messaging/MetaAttribute.scala
@@ -41,7 +41,7 @@ object MetaAttribute extends Enum[MetaAttribute[_]] {
 
   case object Tags extends MetaAttribute[Set[String]] {
     def merge(md1: MetaData, md2: MetaData): Set[String] = {
-      md1.tryGet(Tags).orElse(Some(Set())).flatMap(t1 => md2.tryGet(Tags).map(t1 ++ _)).getOrElse(Set())
+      (md1.tryGet(Tags) ++ md1.tryGet(Tags)).flatten.toSet
     }
   }
 

--- a/akka-ddd-protocol/src/test/scala/pl/newicom/dddd/messaging/MetaAttributeSpec.scala
+++ b/akka-ddd-protocol/src/test/scala/pl/newicom/dddd/messaging/MetaAttributeSpec.scala
@@ -53,5 +53,31 @@ class MetaAttributeSpec extends org.scalatest.FunSuite {
     assert(md != null)
   }
 
+  test("merge meta data empty tags") {
+    val event = MetaData.empty.withAttr(Id, "e-1")
+    val command = MetaData.empty.withAttr(Id, "c-1")
+    val md = MetaDataPropagationPolicy.onCommandSentByPM(event, command)
+    assert(md.tryGet(Tags).exists(_ == Set.empty[String]))
+  }
 
+  test("merge meta data not empty tags on left and empty on right") {
+    val event = MetaData.empty.withAttr(Id, "e-1").withAttr(Tags, Set("t1", "t2"))
+    val command = MetaData.empty.withAttr(Id, "c-1")
+    val md = MetaDataPropagationPolicy.onCommandSentByPM(event, command)
+    assert(md.tryGet(Tags).exists(_ == Set("t1", "t2")))
+  }
+
+  test("merge meta data empty tags on left and non empty on right") {
+    val event = MetaData.empty.withAttr(Id, "e-1")
+    val command = MetaData.empty.withAttr(Id, "c-1").withAttr(Tags, Set("t2", "t3"))
+    val md = MetaDataPropagationPolicy.onCommandSentByPM(event, command)
+    assert(md.tryGet(Tags).exists(_ == Set("t2", "t3")))
+  }
+
+  test("merge meta data non empty tags") {
+    val event = MetaData.empty.withAttr(Id, "e-1").withAttr(Tags, Set("t1", "t2"))
+    val command = MetaData.empty.withAttr(Id, "c-1").withAttr(Tags, Set("t2", "t3"))
+    val md = MetaDataPropagationPolicy.onCommandSentByPM(event, command)
+    assert(md.tryGet(Tags).exists(_ == Set("t1", "t2", "t3")))
+  }
 }


### PR DESCRIPTION
Tags set was always empty if tags from md2 are absent (even if set of tags from md1 is not empty)